### PR TITLE
Set the main window as the parent of the status bar

### DIFF
--- a/src/harbour-schwarzenmaker.cpp
+++ b/src/harbour-schwarzenmaker.cpp
@@ -43,13 +43,13 @@ int main(int argc, char *argv[])
   qmlRegisterType<FileModel>("harbour.schwarzenmaker.FileModel", 1, 0, "FileModel");
 
   appLibrary* applib = new appLibrary();
-  QScopedPointer<ViewHelper> helper(new ViewHelper(application.data()));
   // AvatarImageProvider* avatarImageProvider = new AvatarImageProvider();
 
   QScopedPointer<QQuickView> view(SailfishApp::createView());
   QQmlEngine* engine = view->engine();
   // engine->addImageProvider(QLatin1String("avatarimage"), avatarImageProvider);
   QObject::connect(engine, SIGNAL(quit()), application.data(), SLOT(quit()));
+  QScopedPointer<ViewHelper> helper(new ViewHelper(view.data()));
 
   view->rootContext()->setContextProperty("appLibrary", applib);
   view->rootContext()->setContextProperty("viewHelper", helper.data());

--- a/src/viewhelper.cpp
+++ b/src/viewhelper.cpp
@@ -24,11 +24,13 @@
 #include <QTimer>
 #include <QDebug>
 
-ViewHelper::ViewHelper(QObject *parent) :
+ViewHelper::ViewHelper(QQuickView *parent) :
   QObject(parent),
   m_overlayView(NULL),
   m_overlayActive(false)
 {
+    m_overlayView = SailfishApp::createView();
+    m_overlayView->setParent(parent);
 }
 
 void ViewHelper::checkOverlay()
@@ -48,7 +50,6 @@ void ViewHelper::showOverlay()
   qGuiApp->setApplicationName("Schwarzenmaker Overlay");
   qGuiApp->setApplicationDisplayName("Schwarzenmaker Overlay");
 
-  m_overlayView = SailfishApp::createView();
   m_overlayView->setTitle("SchwarzenmakerOverlay");
 
   QColor color;

--- a/src/viewhelper.h
+++ b/src/viewhelper.h
@@ -117,7 +117,7 @@ class ViewHelper : public QObject
   Q_CLASSINFO("D-Bus Interface", "harbour.schwarzenmaker") // necessary?
 
   public:
-  explicit ViewHelper(QObject *parent = 0);
+  explicit ViewHelper(QQuickView *parent = 0);
 
   // Q_INVOKABLE void closeOverlay();
   // Q_INVOKABLE void startOverlay();


### PR DESCRIPTION
This ensures that the status bar closes when the main window closes.

Fixes #15 (hopefully).